### PR TITLE
[18.0] shopfloor_base: fix default login handling

### DIFF
--- a/shopfloor_mobile_base/static/src/main.esm.js
+++ b/shopfloor_mobile_base/static/src/main.esm.js
@@ -262,9 +262,9 @@ new Vue({
             const self = this;
             return this._loadConfig().then(function (result) {
                 if (result.error) {
-                    self.trigger("login:success", {root: self});
-                } else {
                     self.trigger("login:failure", {root: self});
+                } else {
+                    self.trigger("login:success", {root: self});
                 }
             });
         },


### PR DESCRIPTION
This was broken by the linting fixes that inverted the condition.

See 8d422732.