### PR TITLE
[18.0] shopfloor_base: misc fixes

### DIFF
--- a/shopfloor_base/controllers/main.py
+++ b/shopfloor_base/controllers/main.py
@@ -39,7 +39,7 @@ class ShopfloorController(RestController):
         except AttributeError:
             httprequest = request.httprequest
         if httprequest.mimetype == "application/json":
-            data = httprequest.get_data().decode(httprequest.charset)
+            data = httprequest.get_data().decode()
             if data:
                 try:
                     params.update(json.loads(data))

--- a/shopfloor_base/models/ir_http.py
+++ b/shopfloor_base/models/ir_http.py
@@ -9,6 +9,12 @@ from odoo.http import request
 from odoo.addons.base.models.ir_http import RequestUID
 
 
+# /!\/!\/!\/!\ WARNING /!\/!\//!\/!\//!\/!\//!\/!\//!\/!\//!\/!\
+# This converter does not work with the standard since v18.
+# See https://github.com/odoo/odoo/pull/221005
+# Until a proper fix is implemented,
+# each controller should be responsible for finding the app.
+# See shopfloor_base.controllers.main.ShopfloorMobileAppController
 class TechNameConverter(werkzeug.routing.BaseConverter):
     """Record converter via tech_name field.
 

--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -190,8 +190,10 @@ class ShopfloorApp(models.Model):
         for service in services:
             self._prepare_non_decorated_endpoints(service)
 
-    def _register_controllers(self, init=False, options=None):
-        super()._register_controllers(init=init, options=options)
+    def _register_controllers(self, init=False, options=None, clear_cache=True):
+        super()._register_controllers(
+            init=init, options=options, clear_cache=clear_cache
+        )
         if not self:
             return
         self._register_base_rest_routes()

--- a/shopfloor_base/tests/common_http.py
+++ b/shopfloor_base/tests/common_http.py
@@ -6,7 +6,6 @@ import unittest
 
 import requests
 
-from odoo import tools
 from odoo.tests import HttpCase
 
 from odoo.addons.base_rest.tests.common import RegistryMixin
@@ -67,7 +66,7 @@ class HttpCommonCase(HttpCase, RegistryMixin, ComponentMixin):
         self.shopfloor_app._handle_registry_sync()
 
     def _make_url(self, route):
-        return "http://127.0.0.1:{}{}".format(tools.config["http_port"], route)
+        return f"{self.base_url()}/{route}"
 
     def _make_request(self, route, api_key=None, menu=None, profile=None, headers=None):
         # use requests because you cannot easily manipulate the request w/ `url_open`

--- a/shopfloor_mobile_base/controllers/main.py
+++ b/shopfloor_mobile_base/controllers/main.py
@@ -102,22 +102,41 @@ class ShopfloorMobileAppMixin:
 class ShopfloorMobileAppController(http.Controller, ShopfloorMobileAppMixin):
     @http.route(
         [
-            "/shopfloor/app/<tech_name(shopfloor.app):shopfloor_app>",
-            "/shopfloor/app/<tech_name(shopfloor.app):shopfloor_app>/<string:demo>",
+            # FIXME: this bug in odoo prevents using the `tech_name` converter
+            # because it checks if the record has public access enabled.
+            # https://github.com/odoo/odoo/pull/221005
+            # "/shopfloor/app/<tech_name(shopfloor.app):shopfloor_app>",
+            # "/shopfloor/app/<tech_name(shopfloor.app):shopfloor_app>/<string:demo>",
+            "/shopfloor/app/<string:shopfloor_app>",
+            "/shopfloor/app/<string:shopfloor_app>/<string:demo>",
         ],
         auth="public",
     )
     def load_app(self, shopfloor_app, demo=False, **kw):
+        shopfloor_app = self._get_app(shopfloor_app)
         return self._load_app(shopfloor_app, demo=True if demo else False, **kw)
 
     @http.route(
         [
-            "/shopfloor/app/<tech_name(shopfloor.app):shopfloor_app>/manifest.json",
+            "/shopfloor/app/<string:shopfloor_app>/manifest.json",
         ],
         auth="public",
     )
     def manifest(self, shopfloor_app):
+        shopfloor_app = self._get_app(shopfloor_app)
         manifest = self._get_manifest(shopfloor_app)
         headers = {}
         headers["Content-Type"] = "application/json"
         return http.request.make_response(json.dumps(manifest), headers=headers)
+
+    def _get_app(self, tech_name):
+        # FIXME: workaround for the bug mentioned above.
+        # This work should be done by the `tech_name` converter.
+        shopfloor_app = (
+            http.request.env["shopfloor.app"]
+            .sudo()
+            .search([("tech_name", "=", tech_name)], limit=1)
+        )
+        if not shopfloor_app:
+            raise http.NotFound()
+        return shopfloor_app

--- a/shopfloor_mobile_base/templates/main.xml
+++ b/shopfloor_mobile_base/templates/main.xml
@@ -32,7 +32,7 @@
             <t t-set="head">
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <script type="text/javascript">
-          var shopfloor_app_info = <t t-raw="json.dumps(app_info)" />;
+          var shopfloor_app_info = <t t-out="json.dumps(app_info)" />;
         </script>
                 <t t-call="shopfloor_mobile_base.shopfloor_app_assets" />
                 <t

--- a/shopfloor_mobile_base/tests/__init__.py
+++ b/shopfloor_mobile_base/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_endpoints

--- a/shopfloor_mobile_base/tests/test_endpoints.py
+++ b/shopfloor_mobile_base/tests/test_endpoints.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+
+from odoo.addons.shopfloor_base.tests.common_http import HttpCommonCase
+
+
+class TestEndpointsCase(HttpCommonCase):
+    def test_call(self):
+        route = self.shopfloor_app.url
+        response = self._make_request(route)
+        self.assertEqual(response.status_code, 200)
+
+    def test_call_manifest(self):
+        route = self.shopfloor_app.url + "manifest.json"
+        response = self._make_request(route)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/json")


### PR DESCRIPTION
There's a bug in odoo core that prevents to have full control on how you publish a record.
A sf.app record must be accessible publicly just because we have to load the app.
However, we don't want the sf.app record to be accessible to public users.
Our only purpose is to load the metadata of the app and publish the homepage.
Then the auth mechanisms - that can be different - will take care of the rest.

For now I'm getting rid of the tech name converter until this issue is solved:  https://github.com/odoo/odoo/pull/221005 .