### PR TITLE
[18.0] shopfloor_base: critical fixes

### DIFF
--- a/shopfloor_base/__manifest__.py
+++ b/shopfloor_base/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor Base",
     "summary": "Core module for creating mobile apps",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.0.3",
     "development_status": "Beta",
     "category": "Inventory",
     "website": "https://github.com/OCA/shopfloor-app",

--- a/shopfloor_base/migrations/18.0.1.0.0/post-migrate.py
+++ b/shopfloor_base/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Force update endpoint_route table.
+
+    Critical changes:
+
+    * new `readonly` should be added to the stored route options
+    * route type should be set to `restapi`
+    """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    model = env["shopfloor.app"]
+    records = model.sudo().search([])
+    for app in records:
+        registry = app._endpoint_registry
+        rules = list(registry.get_rules_by_group(app._route_group()))
+        for rule in rules:
+            rule.routing = dict(rule.routing, readonly=True, type="restapi")
+        registry.update_rules(rules)
+    _logger.info(
+        "Forced endpoint route sync on %s records: %s", model._name, records.ids
+    )

--- a/shopfloor_base/migrations/18.0.1.0.3/post-migrate.py
+++ b/shopfloor_base/migrations/18.0.1.0.3/post-migrate.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Force update endpoint_route table.
+
+    Critical changes:
+
+    * new `readonly` should be added to the stored route options
+    * route type should be set to `restapi`
+    """
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    model = env["shopfloor.app"]
+    records = model.sudo().search([])
+    for app in records:
+        registry = app._endpoint_registry
+        rules = list(registry.get_rules_by_group(app._route_group()))
+        for rule in rules:
+            rule.routing = dict(rule.routing, readonly=True, type="restapi")
+        registry.update_rules(rules)
+    _logger.info(
+        "Forced endpoint route sync on %s records: %s", model._name, records.ids
+    )

--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -255,6 +255,12 @@ class ShopfloorApp(models.Model):
         method_name = vals.pop("_method_name")
         route_handler = self.env["endpoint.route.handler.tool"]
         new_route = route_handler.new(vals)
+        # SF endpoints must use the ``restapi`` dispatcher provided by base_rest.
+        # NOTE: this ``route_type`` value
+        # is not declared on `endpoint.route.handler.route_type` field selection,
+        # but is not relevant in this case
+        # because the value is set only on a in memory recordset.
+        new_route.route_type = "restapi"
         new_route._refresh_endpoint_data()
         options = {
             "handler": {

--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -163,7 +163,8 @@ class ShopfloorApp(models.Model):
 
     def _registered_endpoint_rule_keys(self):
         # `endpoint.route.sync.mixin` api
-        return [x[0] for x in self._registered_routes()]
+        # TODO: add tests
+        return [x.key for x in self._registered_routes()]
 
     def _register_hook(self):
         super()._register_hook()

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -65,7 +65,12 @@ class TestShopfloorApp(CommonCase):
                 ),
                 "method_name": "_process_endpoint",
             }
-            self.assertEqual(rule.handler_options, expected_handler_opts)
+            for k, v in expected_handler_opts.items():
+                self.assertEqual(
+                    rule.handler_options[k],
+                    v,
+                    f"{k} differs: {rule.handler_options[k]} != {v}",
+                )
             _check[rule.route] = set(rule.routing["methods"])
         expected = {
             # TODO: review methods
@@ -145,7 +150,10 @@ class TestShopfloorApp(CommonCase):
         )
 
     def test_make_app_manifest(self):
-        param = "http://localhost:8069"
+        self.env["ir.config_parameter"].sudo().set_param(
+            "web.base.url", "http://foo.com"
+        )
+        param = "http://foo.com"
         manifest = self.shopfloor_app._make_app_manifest()
         expected = {
             "name": self.shopfloor_app.name,

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -55,6 +55,7 @@ class TestShopfloorApp(CommonCase):
         routes = rec._registered_routes()
         _check = {}
         for rule in routes:
+            self.assertEqual(rule.routing["type"], "restapi")
             self.assertEqual(rule.route_group, rec._route_group())
             self.assertTrue(rule.endpoint_hash)
             service, endpoint = rule.route.split("/")[-2:]


### PR DESCRIPTION
Several fixes to make it work properly on v18.
Most important fix is

[shopfloor_base: fix routing registration](https://github.com/OCA/shopfloor-app/commit/a2a9c03355e3f0bae16a6408cbd9f5edf7de5678)

The app was not using at all the base_rest dispatcher for restapi route type.
This is because by defualt endpoint.route.handler use only http or json