### PR TITLE
shopfloor_base: fix v18 mig readonly flag

### DIFF
--- a/shopfloor_base/migrations/18.0.1.0.0/post-migrate.py
+++ b/shopfloor_base/migrations/18.0.1.0.0/post-migrate.py
@@ -25,7 +25,7 @@ def migrate(cr, version):
         registry = app._endpoint_registry
         rules = list(registry.get_rules_by_group(app._route_group()))
         for rule in rules:
-            rule.routing = dict(rule.routing, readonly=True, type="restapi")
+            rule.routing = dict(rule.routing, readonly=False, type="restapi")
         registry.update_rules(rules)
     _logger.info(
         "Forced endpoint route sync on %s records: %s", model._name, records.ids

--- a/shopfloor_base/migrations/18.0.1.0.3/post-migrate.py
+++ b/shopfloor_base/migrations/18.0.1.0.3/post-migrate.py
@@ -25,7 +25,7 @@ def migrate(cr, version):
         registry = app._endpoint_registry
         rules = list(registry.get_rules_by_group(app._route_group()))
         for rule in rules:
-            rule.routing = dict(rule.routing, readonly=True, type="restapi")
+            rule.routing = dict(rule.routing, readonly=False, type="restapi")
         registry.update_rules(rules)
     _logger.info(
         "Forced endpoint route sync on %s records: %s", model._name, records.ids

--- a/shopfloor_base/utils.py
+++ b/shopfloor_base/utils.py
@@ -102,7 +102,19 @@ def register_new_services(env, *component_classes, apps=None):
     if not components:
         return
     apps = apps or env["shopfloor.app"].search([])
-    apps.with_context(sf_service_components=components)._register_controllers()
+    force_register_controllers(
+        env, apps=apps.with_context(sf_service_components=components)
+    )
+
+
+def force_register_controllers(env, apps=None):
+    """Force re-registration of all services endpoints for all apps.
+
+    Useful when the component registry is not fully ready
+    at module install time and some services are missing their routes.
+    """
+    apps = apps or env["shopfloor.app"].search([])
+    apps._register_controllers()
 
 
 def load_components_without_registry(env, *component_classes):


### PR DESCRIPTION
The flag should be set to false. Enforcing the registration of the routes anyway would solve the problem
as the flag is properly set by route handle machinery.

Additional change: split util to ease reuse.

See atomic commits.